### PR TITLE
fix DRM video decoding

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1414,7 +1414,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>-v debug=0x100 keepsyms=1 npci=0x2000 alcid=1</string>
+				<string>-v debug=0x100 keepsyms=1 npci=0x2000 alcid=1 shikigva=80</string>
 				<key>csr-active-config</key>
 				<data>5wMAAA==</data>
 				<key>prev-lang:kbd</key>


### PR DESCRIPTION
修复 TV、Netflix 等带有 DRM 的视频解码黑屏问题。

在我的设备上测试可用。

### 我的设备配置清单

| 类型 | 型号              |
| ---- | ----------------- |
| 主板 | 微星 B450m 迫击炮 |
| CPU  | AMD R5 2600     |
| 显卡 | 盈通 RX 590     |